### PR TITLE
Changes for hw3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ $U/usys.o : $U/usys.S
 $U/_forktest: $U/forktest.o $(ULIB)
 	# forktest has less library code linked in - needs to be small
 	# in order to be able to max out the proc table.
-	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $U/_forktest $U/forktest.o $U/ulib.o $U/usys.o
+	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $U/_forktest $U/forktest.o $U/ulib.o $U/usys.o $U/printf.o $U/umalloc.o
 	$(OBJDUMP) -S $U/_forktest > $U/forktest.asm
 
 mkfs/mkfs: mkfs/mkfs.c $K/fs.h $K/param.h

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -366,6 +366,8 @@ exit(int status)
 	// Jump into the scheduler, never to return.
 	sched();
 	panic("zombie exit");
+
+	return;
 }
 
 // Wait for a child process to exit and return its pid.

--- a/user/sh.c
+++ b/user/sh.c
@@ -52,7 +52,7 @@ struct backcmd {
 int         fork1(void); // Fork but panics on failure.
 void        panic(char *);
 struct cmd *parsecmd(char *);
-void        runcmd(struct cmd *) __attribute__((noreturn));
+void        runcmd(struct cmd *);
 
 // Execute cmd.  Never returns.
 void

--- a/user/user.h
+++ b/user/user.h
@@ -2,7 +2,7 @@ struct stat;
 
 // system calls
 int   fork(void);
-int   exit(int) __attribute__((noreturn));
+int   exit(int);
 int   wait(int *);
 int   pipe(int *);
 int   write(int, const void *, int);

--- a/user/usertests.c
+++ b/user/usertests.c
@@ -2971,6 +2971,7 @@ run(void f(char *), char *s)
 			printf("OK\n");
 		return xstatus == 0;
 	}
+	while (1);
 }
 
 int


### PR DESCRIPTION
Changes made:
- Changed `exit` and `runcmd` to return. Added corresponding return statements.
- Added infinite loop at the end of run in `usertests`.
- Added `umalloc.o` in `forktest` in the `Makefile` so user libraries can use `malloc`.

Changes not made but requested and awaiting Gabe's verdict:
- Update the comments on line 186-191 in `trap.c` as it implies that students must make additional changes in those functions.